### PR TITLE
タスクタイプの定義で省略記法を使えるようにします。

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -1,8 +1,12 @@
 user_name: nissyi
 task_types:
-  - Ruby
-  - TypeScript
-  - Other
+  - short: r
+    long: Ruby
+  - short: t
+    long: TypeScript
+  - short: o
+    long: Other
+  - NotHasShortHand
 destinations:
   - name: Slack
     url: notification_url

--- a/lib/task_pegion/cli.rb
+++ b/lib/task_pegion/cli.rb
@@ -43,7 +43,12 @@ module TaskPegion
 
         loop do
           task_type = gets.chomp
-          return task_type if config.task_types.include?(task_type)
+          config.task_types.each do |k, v|
+            if task_type == k
+              puts "You selected '#{v}'"
+              return v
+            end
+          end
 
           puts 'Please input valid task type'
         end
@@ -51,12 +56,8 @@ module TaskPegion
 
       def show_task_types
         puts 'Your task types:'
-        config.task_types.each do |task_types|
-          if task_types.is_a?(Hash)
-            puts "#{task_types.keys[0]}: #{task_types.values[0]}"
-          else
-            puts task_types
-          end
+        config.task_types.each do |k, v|
+          puts k == v ? k : "#{k}: #{v}"
         end
         puts ''
       end

--- a/lib/task_pegion/cli.rb
+++ b/lib/task_pegion/cli.rb
@@ -51,8 +51,12 @@ module TaskPegion
 
       def show_task_types
         puts 'Your task types:'
-        config.task_types.each_slice(3) do |task_types|
-          puts task_types.join(' ')
+        config.task_types.each do |task_types|
+          if task_types.is_a?(Hash)
+            puts "#{task_types.keys[0]}: #{task_types.values[0]}"
+          else
+            puts task_types
+          end
         end
         puts ''
       end

--- a/lib/task_pegion/config.rb
+++ b/lib/task_pegion/config.rb
@@ -9,7 +9,7 @@ module TaskPegion
 
     def initialize
       @user_name = config_file['user_name']
-      @task_types = config_file['task_types']
+      @task_types = task_converter(config_file['task_types'])
       @destinations = config_file['destinations']
     end
 
@@ -21,6 +21,19 @@ module TaskPegion
       else
         { 'task_types' => %w[Main Sub Other] }
       end
+    end
+
+    def task_converter(task_types)
+      task_types.map do |task_type|
+        if task_type['short'] && task_type['long']
+          { task_type['short'] => task_type['long'] }
+        # short only, or long only is invalid
+        elsif task_type.is_a?(Hash)
+          puts "#{task_type} is invalid. if you want to set the short and long, please set both."
+        else
+          task_type
+        end
+      end.compact
     end
   end
 end

--- a/lib/task_pegion/config.rb
+++ b/lib/task_pegion/config.rb
@@ -26,14 +26,14 @@ module TaskPegion
     def task_converter(task_types)
       task_types.map do |task_type|
         if task_type['short'] && task_type['long']
-          { task_type['short'] => task_type['long'] }
+          [task_type['short'], task_type['long']]
         # short only, or long only is invalid
         elsif task_type.is_a?(Hash)
           puts "#{task_type} is invalid. if you want to set the short and long, please set both."
         else
-          task_type
+          [task_type, task_type]
         end
-      end.compact
+      end.to_h
     end
   end
 end


### PR DESCRIPTION
長いタスク名を入力するのが手間なので楽したいです。